### PR TITLE
added created_on to comment data

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -88,3 +88,5 @@ CREATE TABLE "Categories" (
 INSERT INTO Categories ('label') VALUES ('News');
 INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
+
+ALTER TABLE Comments ADD "created_on" date;

--- a/views/comment.py
+++ b/views/comment.py
@@ -8,9 +8,14 @@ def create_comment(comment):
         db_cursor = conn.cursor()
         db_cursor.execute(
             """
-            INSERT INTO Comments (post_id, author_id, content) VALUES (?,?,?)
+            INSERT INTO Comments (post_id, author_id, content, created_on) VALUES (?,?,?,?)
         """,
-            (comment["post_id"], comment["author_id"], comment["content"]),
+            (
+                comment["post_id"],
+                comment["author_id"],
+                comment["content"],
+                comment["created_on"],
+            ),
         )
 
         new_comment_id = db_cursor.lastrowid
@@ -30,6 +35,7 @@ def list_comments():
             c.post_id,
             c.author_id,
             c.content,
+            c.created_on,
             u.username
         FROM Comments c
         JOIN Users u ON u.id = c.author_id


### PR DESCRIPTION
I added a created_on property to the comment data. To ensure this works properly, run the command at the bottom of the loaddata.sql file:
`ALTER TABLE Comments ADD "created_on" date;`
This will not add dates to any previous comments, but will ensure that comments created in the future will have a valid date property. 